### PR TITLE
Code fellowship weds

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ spring.jpa.generate-ddl=true
 
 ## Feature Tasks
 
+### Wednesday
+
+- [ ] Allow users to log in to CodeFellowship, view user profiles, and create posts.
+- [ ] Upon logging in, users should be taken to a /myprofile route that displays their information.
+- [X] This should include a default profile picture, which is the same for every user, and their basic information from ApplicationUser.
+- [ ] The site should have a page which allows viewing the data about a single ApplicationUser, at a route like /users/{id}.
+- [X] This should include a default profile picture, which is the same for every user, and their basic information.
+- [ ] Continue to ensure that your homepage, login, and registration routes are accessible to non-logged in users. All other routes should be limited to logged-in users.
+- [X] Add a Post entity to your app.
+- [X] A Post has a body and a createdAt timestamp.
+- [ ] A logged-in user should be able to create a Post, and a post should belong to the user that created it.
+      Hint: This is a relationship between two pieces of data
+
+- [ ] A user’s posts should be visible on their profile page.
+- [ ] The site should use reusable templates for its information. (At a minimum, it should have one Thymeleaf fragment that is used on multiple pages.)
+- [ ] The site should have a non-whitelabel error handling page that lets the user know, at minimum, the error code and a brief message about what went wrong.
+
+### Tuesday
+
 - [X] build a webapp that allows users to log into CodeFellowship
 - [X] single login page
 - [X] login page has link to signup page

--- a/README.md
+++ b/README.md
@@ -37,12 +37,22 @@ server.error.whitelabel.enabled=false
 
 ## Feature Tasks
 
+Current state: I am in the process of building this application to the standards of Lab 17.
+
+'X' or checked list items below are completed but may not have been tested, with the exception of "default profile picture" which was implemented and tested yesterday.
+
+'~' or tilde list items are partially implemented.
+
+The WebApp will build and run without error.
+
+There will be little (if any) live indication that today's feature implementations are enabled.
+
 ### Wednesday
 
 - [ ] Allow users to log in to CodeFellowship, view user profiles, and create posts.
 - [ ] Upon logging in, users should be taken to a /myprofile route that displays their information.
 - [X] This should include a default profile picture, which is the same for every user, and their basic information from ApplicationUser.
-- [ ] The site should have a page which allows viewing the data about a single ApplicationUser, at a route like /users/{id}.
+- [~] The site should have a page which allows viewing the data about a single ApplicationUser, at a route like /users/{id}.
 - [X] This should include a default profile picture, which is the same for every user, and their basic information.
 - [ ] Continue to ensure that your homepage, login, and registration routes are accessible to non-logged in users. All other routes should be limited to logged-in users.
 - [X] Add a Post entity to your app.
@@ -52,7 +62,7 @@ server.error.whitelabel.enabled=false
 
 - [ ] A user’s posts should be visible on their profile page.
 - [ ] The site should use reusable templates for its information. (At a minimum, it should have one Thymeleaf fragment that is used on multiple pages.)
-- [ ] The site should have a non-whitelabel error handling page that lets the user know, at minimum, the error code and a brief message about what went wrong.
+- [~] The site should have a non-whitelabel error handling page that lets the user know, at minimum, the error code and a brief message about what went wrong.
 
 ### Tuesday
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ spring.datasource.username=your_postgres_admin_username
 spring.datasource.password=your_postgres_admin_password
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.generate-ddl=true
+spring.mvc.hiddenmethod.filter.enabled=true
+server.error.whitelabel.enabled=false
 ```
+*Note*: This application.properties template code has been updated to the requirements in [Wednesday](#wednesday)'s project work.
 
 ## Feature Tasks
 

--- a/src/main/java/com/fellowshipOfTheCode/jrCodeFellowship/ApplicationUser.java
+++ b/src/main/java/com/fellowshipOfTheCode/jrCodeFellowship/ApplicationUser.java
@@ -113,4 +113,6 @@ public class ApplicationUser implements UserDetails {
     public void setBio(String bio) {
         this.bio = bio;
     }
+
+    public Long getId() { return this.id; }
 }

--- a/src/main/java/com/fellowshipOfTheCode/jrCodeFellowship/UserPost.java
+++ b/src/main/java/com/fellowshipOfTheCode/jrCodeFellowship/UserPost.java
@@ -1,0 +1,47 @@
+package com.fellowshipOfTheCode.jrCodeFellowship;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.text.DateFormat;
+
+@Entity
+public class UserPost {
+    @Id
+    @GeneratedValue(strategy= GenerationType.AUTO) Long id;
+
+    private String body;
+    private DateFormat timestamp;
+
+    public UserPost() {    }
+
+    public UserPost(String body, DateFormat timestamp) {
+        this.body = body;
+        this.timestamp = timestamp;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public DateFormat getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(DateFormat timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/src/main/java/com/fellowshipOfTheCode/jrCodeFellowship/controllers/HomeController.java
+++ b/src/main/java/com/fellowshipOfTheCode/jrCodeFellowship/controllers/HomeController.java
@@ -2,10 +2,14 @@ package com.fellowshipOfTheCode.jrCodeFellowship.controllers;
 
 import com.fellowshipOfTheCode.jrCodeFellowship.ApplicationUser;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import com.fellowshipOfTheCode.jrCodeFellowship.repository.AppRepository;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
 import java.security.Principal;
 
 @Controller
@@ -25,5 +29,33 @@ public class HomeController {
         }
 
         return "index";
+    }
+
+    @GetMapping("/user/{id}")
+    public String getUserInfo(Principal principal, Model springModel, @PathVariable Long id) {
+        // session info ??
+        if (principal != null) {
+            String username = principal.getName();
+            ApplicationUser applicationUser = appRepository.findByUsername(username);
+
+            // store authenticated username for thymeleaf
+            springModel.addAttribute("username",username);
+        }
+
+        // get user info from DB
+        ApplicationUser applicationUser = appRepository.findById(id).orElseThrow();
+
+        // set thymeleaf attributes for an authenticated user's display data (for a null user??)
+        springModel.addAttribute("appUsername", applicationUser.getUsername());
+        springModel.addAttribute("appUserId", applicationUser.getId());
+
+        // return the name of the template to load
+        return "/userprofile"; // alex used user-info
+    }
+
+    // custom http 404 response code
+    @ResponseStatus(value = HttpStatus.NOT_FOUND)
+    public class ResourceNotFoundException extends RuntimeException {
+        ResourceNotFoundException(String message) { super(message); }
     }
 }

--- a/src/main/java/com/fellowshipOfTheCode/jrCodeFellowship/repository/UserPostRepository.java
+++ b/src/main/java/com/fellowshipOfTheCode/jrCodeFellowship/repository/UserPostRepository.java
@@ -1,0 +1,10 @@
+package com.fellowshipOfTheCode.jrCodeFellowship.repository;
+
+import com.fellowshipOfTheCode.jrCodeFellowship.UserPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.text.DateFormat;
+
+public interface UserPostRepository extends JpaRepository<UserPost, Long> {
+    UserPost findByTimestamp(DateFormat timestamp);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,5 @@ spring.datasource.username=postgres
 spring.datasource.password=eidk1Lazmxn!
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.generate-ddl=true
+spring.mvc.hiddenmethod.filter.enabled=true
+server.error.whitelabel.enabled=false

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <!-- CSS only -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor"
+          crossorigin="anonymous">
+    <title>ERROR</title>
+</head>
+<body>
+<h3 class=".fs-1 fw-bold text-center text-warning bg-dark">An error has occurred!</h3>
+<p>Thymeleaf will produce error information here.</p>
+<!-- <span th:if="${exception}" th:text="${message}"></span> -->
+</body>
+</html>

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+      <html lang="en" xmlns:th="http://www.thymeleaf.org">
+      <head>
+      <meta charset="UTF-8">
+      <!-- CSS only -->
+      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor"
+      crossorigin="anonymous">
+      <title>Profile Page</title>
+</head>
+<body>
+<header class="bg-danger p-2 text-white">
+  <h1 class="text-center">Code Fellowship Profile Page</h1>
+</header>
+
+<main class="bg-light p-2 text-body">
+  <h3 class=".fs-1 fw-bold text-center">
+    View user profile information.</h3>
+  <h3 class=".fs-1 text-center">
+    <strong>Coming soon!</strong> If you are currently logged-on and this is your profile you should have the ability to post.
+  </h3>
+
+  <div class="card" style="width:200px" th:if="${appuser != null}">
+    <img src="https://place-hold.it/100x100/22/ff.png&text=user&bold&fontsize=12"
+         class="card-img-top"
+         alt="placeholder image for the currently logged in user."
+    >
+    <div class="card-body">
+      <h4>Current user: <span th:text="${appuser.firstName}"></span>
+        <span th:text="${appuser.lastName}"></span>
+      </h4>
+
+      <p>Birthdate: <span th:text="${appuser.dateOfBirth}"></span></p>
+      <br />
+      <p>About You:</p>
+      <p class="fst-italic" th:text="${appuser.bio}"></p>
+      <a href="/logout">Log Out</a>
+    </div>
+
+    <!-- TODO: for each post in posts display in a modified card format in descending creationdate order -->
+
+  </div>
+
+
+  <div th:if="${appuser == null}">
+    <p class="text-center">Please <a href="/signup">register</a> to <span class="fw-bold">join us</span>.</p>
+    <p class="text-center">Already registered?<a href="/login"><span class="fw-bold"> Sign In</span></a></p>
+  </div>
+
+</main>
+</body>
+</html></title>
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
Current state: I am in the process of building this application to the standards of Lab 17.

'X' or checked list items below are completed but may not have been tested, with the exception of "default profile picture" which was implemented and tested yesterday.

'~' or tilde list items are partially implemented.

The WebApp will build and run without error.

There will be little (if any) live indication that today's feature implementations are enabled.

## Feature Tasks Checklist

- [ ] Allow users to log in to CodeFellowship, view user profiles, and create posts.
- [ ] Upon logging in, users should be taken to a /myprofile route that displays their information.
- [X] This should include a default profile picture, which is the same for every user, and their basic information from ApplicationUser.
- [~] The site should have a page which allows viewing the data about a single ApplicationUser, at a route like /users/{id}.
- [X] This should include a default profile picture, which is the same for every user, and their basic information.
- [ ] Continue to ensure that your homepage, login, and registration routes are accessible to non-logged in users. All other routes should be limited to logged-in users.
- [X] Add a Post entity to your app.
- [X] A Post has a body and a createdAt timestamp.
- [ ] A logged-in user should be able to create a Post, and a post should belong to the user that created it.
      Hint: This is a relationship between two pieces of data

- [ ] A user’s posts should be visible on their profile page.
- [ ] The site should use reusable templates for its information. (At a minimum, it should have one Thymeleaf fragment that is used on multiple pages.)
- [~] The site should have a non-whitelabel error handling page that lets the user know, at minimum, the error code and a brief message about what went wrong.
